### PR TITLE
Update ansible version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Use Ansible 2.10 for better collections handling
-ansible>=2.10.0,<2.11.0
+# Use Ansible 5 for consistent Rocky 9 behaviour
+ansible>=5,<6


### PR DESCRIPTION
Ansible version 2.10 reports the Rocky Linux OS family as Rocky, rather than RedHat, which causes problems in roles such as in the os-images role here:
https://github.com/stackhpc/ansible-role-os-images/blob/4696b3112d216c5cb2d871c6a98e91845a274147/tasks/images.yml#L3