### PR TITLE
Small fix for magnum networking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,12 @@ Install Ansible role and collection dependencies from Ansible Galaxy:
        -p ansible/collections \
        -r requirements.yml
 
+Configuration
+=============
+
+Configuration should be added to ``etc/openstack-config/openstack-config.yml``.
+Examples are provided in the ``examples`` directory.
+
 Usage
 =====
 

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -88,7 +88,7 @@ openstack_subnet_external:
   name: "{{ openstack_network_external_name }}"
   project: "admin"
   cidr: "192.168.38.0/24"
-  no_gateway_ip: true
+  gateway_ip: "192.168.38.3"
   allocation_pool_start: "192.168.38.129"
   allocation_pool_end: "192.168.38.254"
 


### PR DESCRIPTION
External subnet was missing gateway (pointing to seed node).
While spawning cluster was failing to pull containers.