### PR TITLE
Add simplified Magnum template generation playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,10 @@ ansible/collections/**/
 *~
 .*.swp
 .*sw?
+
+# Ignore working dirs
+ansible/openstack-config-image-cache
+ansible/openstack-config-venv
+
+# Ignore tmp output from template generation playbook
+generated-magnum-snippets/

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,8 @@ variables in `etc/openstack-config.yml`
 
 .. code-block:: yaml
 
-   magnum_default_flavor_name: # Chosen flavor on target cloud
+   magnum_default_master_flavor_name: # Chosen flavor on target cloud
+   magnum_default_worker_flavor_name: # Chosen flavor on target cloud
    magnum_external_net_name: # External network
    magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
 

--- a/README.rst
+++ b/README.rst
@@ -76,3 +76,32 @@ configuration parameter:
 .. code-block::
 
    $ tools/openstack-config -- --vault-password-file config-secret.vault
+
+
+Magnum Cluster Templates
+========================
+
+To generate a new set of Magnum cluster templates and corresponding Glance image
+definitions which utilise the latest stable upstream release tag, set the following
+variables in `etc/openstack-config.yml`
+
+.. code-block:: yaml
+
+   magnum_flavor_name: # Chosen flavor on target cloud
+   magnum_external_net_name: # External network
+   magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
+
+then run the provided playbook with
+
+.. code-block:: bash
+
+   $ tools/openstack-config -p ansible/generate-magnum-capi-templates.yml
+
+This will create a ``generated-magnum-snippets`` directory in the repo root with
+a timestamped sub-directory containing an ``images.yml`` file and a ``templates.yml``
+file. The contents of these two files can then be added to any existing images and
+cluster templates in ``etc/openstack-config.yml``. When deploying the updated config,
+be sure to run the ``openstack-images.yml`` playbook *before* running the
+``openstack-container-clusters.yml`` playbook, otherwise the Magnum API will return
+an error referencing an invalid cluster type with image ``None``. This is handled
+automatically if running the full ``openstack.yml`` playbook.

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ variables in `etc/openstack-config.yml`
 
 .. code-block:: yaml
 
-   magnum_flavor_name: # Chosen flavor on target cloud
+   magnum_default_flavor_name: # Chosen flavor on target cloud
    magnum_external_net_name: # External network
    magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
 

--- a/ansible/generate-magnum-capi-templates.yml
+++ b/ansible/generate-magnum-capi-templates.yml
@@ -1,0 +1,46 @@
+---
+- name: Generate cluster templates
+  hosts: localhost
+  vars:
+    root_dir: ../
+  tasks:
+
+  - name: Fetch capi-helm-charts release information
+    ansible.builtin.uri:
+      url: https://api.github.com/repos/stackhpc/capi-helm-charts/releases/latest
+    register: capi_helm_chart_release_data
+
+  - name: Fetch dependencies.json for capi-helm-charts release
+    ansible.builtin.uri:
+      url: https://raw.githubusercontent.com/stackhpc/capi-helm-charts/{{ capi_helm_chart_release_data.json.tag_name }}/dependencies.json
+    register: dependencies_response
+
+  - name: Fetch manifest.json for capi-helm-charts images
+    # ansible.builtin.uri:
+    #   url: https://raw.githubusercontent.com/stackhpc/azimuth-images/{{ dependencies_response.json['azimuth-images'] }}/manifest.json
+    # Above URL returns 404 even though similar URL for capi-helm-charts repo works fine
+    # Not sure why but fall back to wget + JSON parsing for now.
+    shell: "wget -O - https://github.com/stackhpc/azimuth-images/releases/download/{{ dependencies_response.json['azimuth-images'] }}/manifest.json"
+    register: manifest_response
+    changed_when: false
+
+  - name: Parse JSON response
+    set_fact:
+      new_template_data: "{{ manifest_response.stdout | from_json | dict2items | selectattr('key', 'match', 'kubernetes*') | list }}"
+
+  - name: Ensure output dir exists
+    ansible.builtin.file:
+      path: "{{ [root_dir, 'generated-magnum-snippets', now(utc=true,fmt='%Y-%m-%d-T%H-%M-%S')] | path_join }}"
+      state: directory
+      mode: '0755'
+    register: output_dir
+
+  - name: Write new image config to file
+    template:
+      src: "magnum-capi-images.j2"
+      dest: "{{ output_dir.path }}/images.yml"
+
+  - name: Write new cluster template config to file
+    template:
+      src: "magnum-capi-templates.j2"
+      dest: "{{ output_dir.path }}/templates.yml"

--- a/ansible/generate-magnum-capi-templates.yml
+++ b/ansible/generate-magnum-capi-templates.yml
@@ -5,6 +5,14 @@
     root_dir: ../
   tasks:
 
+  - name: Check that required variables are defined
+    assert:
+      that:
+        - magnum_default_master_flavor_name is defined
+        - magnum_default_worker_flavor_name is defined
+        - magnum_external_net_name is defined
+        - magnum_loadbalancer_provider is defined
+
   - name: Fetch capi-helm-charts release information
     ansible.builtin.uri:
       url: https://api.github.com/repos/stackhpc/capi-helm-charts/releases/latest
@@ -14,6 +22,12 @@
     ansible.builtin.uri:
       url: https://raw.githubusercontent.com/stackhpc/capi-helm-charts/{{ capi_helm_chart_release_data.json.tag_name }}/dependencies.json
     register: dependencies_response
+
+  - name: Ensure wget packages is installed
+    become: true
+    package:
+      name: wget
+      state: present
 
   - name: Fetch manifest.json for capi-helm-charts images
     # ansible.builtin.uri:

--- a/ansible/templates/magnum-capi-images.j2
+++ b/ansible/templates/magnum-capi-images.j2
@@ -1,0 +1,24 @@
+# Images required for corresponding Magnum cluster template
+# To make use of the generated config snippets, copy them to
+# etc/openstack-config and add the images to the openstack_images
+# list.
+
+# List snippet to add to existing openstack_images:
+{% for item in new_template_data %}
+# -{% raw %} "{{ {% endraw %}{{ item.value.name |  replace('-', '_') | replace('.', '_') }}{% raw %} }}"{% endraw %}
+
+{% endfor %}
+
+{% for item in new_template_data %}
+# Image for {{ item.key }}
+{{ item.value.name |  replace('-', '_') | replace('.', '_') }}:
+  name: "{{ item.value.name }}"
+  type: qcow2
+  image_url: "{{ item.value.url }}"
+  visibility: "community"
+  properties:
+    os_distro: "ubuntu"
+    os_version: "20.04"
+    kube_version: "{{ item.value.kubernetes_version }}"
+
+{% endfor %}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,8 +16,8 @@
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
   external_network_id: {{ magnum_external_net_name }}
-  master_flavor: {{ magnum_flavor_name }}
-  flavor: {{ magnum_flavor_name }}
+  master_flavor: {{ magnum_default_flavor_name }}
+  flavor: {{ magnum_default_flavor_name }}
   image: "{{ item.value.name }}"
   name: "{{ item.key }}"
   coe: "kubernetes"

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -1,0 +1,30 @@
+# Magnum cluster templates generated using latest upstream release tags
+# To make use of the generated config snippets, copy them to the 
+# openstack_container_clusters_templates list.
+
+# List snippet to add to existing openstack_container_clusters_templates:
+{% for item in new_template_data %}
+# -{% raw %} "{{ {% endraw %}{{ item.key | replace('-', '_') }}_{{ item.value.kubernetes_version | replace('.', '_') }}{% raw %} }}"{% endraw %}
+
+{% endfor %}
+
+{% for item in new_template_data %}
+{{ item.key | replace('-', '_') }}_{{ item.value.kubernetes_version | replace('.', '_') }}:
+  labels:
+    monitoring_enabled: "True"
+    kube_dashboard_enabled: "True"
+    capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
+    octavia_provider: {{ magnum_loadbalancer_provider }}
+  external_network_id: {{ magnum_external_net_name }}
+  master_flavor: {{ magnum_flavor_name }}
+  flavor: {{ magnum_flavor_name }}
+  image: "{{ item.value.name }}"
+  name: "{{ item.key }}"
+  coe: "kubernetes"
+  network_driver: "calico"
+  master_lb_enabled: "True"
+  floating_ip_enabled: "True"
+  dns_nameserver: "1.1.1.1,8.8.8.8,8.8.4.4"
+  public: True
+
+{% endfor %}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,15 +16,15 @@
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
   external_network_id: {{ magnum_external_net_name }}
-  master_flavor: {{ magnum_default_flavor_name }}
-  flavor: {{ magnum_default_flavor_name }}
+  master_flavor: {{ magnum_default_master_flavor_name }}
+  flavor: {{ magnum_default_worker_flavor_name }}
   image: "{{ item.value.name }}"
   name: "{{ item.key }}"
   coe: "kubernetes"
-  network_driver: "calico"
-  master_lb_enabled: "True"
-  floating_ip_enabled: "True"
-  dns_nameserver: "1.1.1.1,8.8.8.8,8.8.4.4"
-  public: True
+  network_driver: "{{ magnum_default_network_driver | default('calico') }}"
+  master_lb_enabled: "{{ magnum_master_lb_enabled | default('True') }}"
+  floating_ip_enabled: "{{ magnum_cluster_floating_ip_enabled | default('True') }}"
+  dns_nameserver: "{{ (magnum_cluster_default_dns_nameservers | default(['1.1.1.1', '8.8.8.8', '8.8.4.4'])) | join(',') }}"
+  public: "{{ magnum_cluster_templates_public | default('True') }}"
 
 {% endfor %}

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -63,6 +63,37 @@
 # stackhpc.os-container-clusters role.
 #openstack_container_clusters_templates:
 
+# Configuration variables for generating new cluster template config.
+# These variables must be defined before using the generating new cluster
+# templates - see repo README for more details.
+
+# Must have at least 2 CPUs, 4GB RAM and 20GB disk
+# magnum_default_master_flavor_name:
+# magnum_default_worker_flavor_name:
+
+# Network to create tenant cluster FIPs on
+# magnum_external_net_name:
+
+# Provider for cluster loadbalancers (e.g. 'ovn')
+# magnum_loadbalancer_provider:
+
+# Kubernetes CNI to use for cluster templates (defaults to 'calico')
+# Must be one of the options supported by capi-helm-charts, see
+# https://github.com/stackhpc/capi-helm-charts/tree/main/charts/cluster-addons#container-network-interface-cni-plugins
+# magnum_default_network_driver:
+
+# Whether to create a master nodes loadbalancer for cluster templates (defaults to 'True')
+# magnum_master_lb_enabled:
+
+# Whether to add a floating IP to the loadbalancer for cluster templates (defaults to 'True')
+# magnum_cluster_floating_ip_enabled:
+
+# List of nameservers to use for cluster templates
+# magnum_cluster_default_dns_nameservers:
+
+# Whether generated cluster templates should be public by default (defaults to 'True')
+# magnum_cluster_templates_public:
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -63,7 +63,9 @@
 # stackhpc.os-container-clusters role.
 #openstack_container_clusters_templates:
 
-# Configuration variables for generating new cluster template config.
+###############################################################################
+# Configuration variables for generating new Magnum cluster template config.
+
 # These variables must be defined before using the generating new cluster
 # templates - see repo README for more details.
 


### PR DESCRIPTION
Simplified version of #13. Doesn't include any functionality to automatically hide old templates or to auto-merge new templates with existing config but can be built on in the future as needed.