### PR TITLE
feat!: bump `stackhpc.openstack` collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: openstack.cloud
     version: 2.1.0
   - name: stackhpc.openstack
-    version: 0.1.0
+    version: 0.1.1


### PR DESCRIPTION
This version increase brings [ansible-collection-openstack/PR#33](https://github.com/stackhpc/ansible-collection-openstack/pull/33/files) which resolves an issue whereby the virtual environment is set incorrectly causing the configuration of OpenStack projects to fail.