### PR TITLE
Allow extra labels in generated Magnum cluster templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,10 +88,16 @@ variables in `etc/openstack-config.yml`
 
 .. code-block:: yaml
 
-   magnum_default_master_flavor_name: # Chosen flavor on target cloud
-   magnum_default_worker_flavor_name: # Chosen flavor on target cloud
-   magnum_external_net_name: # External network
-   magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
+   # Chosen flavor on target cloud
+   magnum_default_master_flavor_name:
+   # Chosen flavor on target cloud
+   magnum_default_worker_flavor_name:
+   # External network to use for load balancers etc.
+   magnum_external_net_name:
+   # Octavia provider (e.g. 'ovn')
+   magnum_loadbalancer_provider:
+   # Optional list of extra labels to add to all generated cluster templates
+   magnum_template_extra_labels:
 
 then run the provided playbook with
 

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,6 +16,9 @@
     keystone_auth_enabled: "false"
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
+{% if magnum_template_extra_labels is defined %}
+    {{ magnum_template_extra_labels | to_nice_yaml | indent(4) -}}
+{% endif %}
   external_network_id: {{ magnum_external_net_name }}
   master_flavor: {{ magnum_default_master_flavor_name }}
   flavor: {{ magnum_default_worker_flavor_name }}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,7 +16,7 @@
     keystone_auth_enabled: "false"
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
-{% if magnum_template_extra_labels is defined %}
+{% if magnum_template_extra_labels is defined and magnum_template_extra_labels is not none %}
     {{ magnum_template_extra_labels | to_nice_yaml | indent(4) -}}
 {% endif %}
   external_network_id: {{ magnum_external_net_name }}


### PR DESCRIPTION
This makes it more convenient to add extra config required for all templates (e.g. a dedicated SSD volume for etcd).