### PR TITLE
Allow unlimited server groups for Octavia

### DIFF
--- a/examples/projects-octavia.yml
+++ b/examples/projects-octavia.yml
@@ -27,3 +27,4 @@ openstack_octavia_unlimited_quotas:
   ram: -1
   security_group: -1
   security_group_rule: -1
+  server-groups: -1


### PR DESCRIPTION
This is necessary to avoid reaching quota limits when Octavia is configured with `enable_anti_affinity=True`.