### PR TITLE
Support configuring Cinder volume types

### DIFF
--- a/ansible/openstack-volume-types.yml
+++ b/ansible/openstack-volume-types.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure OpenStack volume types exist
+  hosts: localhost
+  tags:
+    - volume-types
+  roles:
+    - role: stackhpc.openstack.os_volumes
+      os_volumes_venv: "{{ openstack_venv }}"
+      os_volumes_auth_type: "{{ openstack_auth_type }}"
+      os_volumes_auth: "{{ openstack_auth }}"
+      os_volumes_cacert: "{{ openstack_cacert }}"
+      os_volumes_types: "{{ openstack_volumes_types }}"

--- a/ansible/openstack.yml
+++ b/ansible/openstack.yml
@@ -5,5 +5,6 @@
 - import_playbook: openstack-flavors.yml
 - import_playbook: openstack-images.yml
 - import_playbook: openstack-host-aggregates.yml
+- import_playbook: openstack-volume-types.yml
 - import_playbook: openstack-container-clusters.yml
 - import_playbook: openstack-ratings.yml

--- a/examples/volume-types.yml
+++ b/examples/volume-types.yml
@@ -1,0 +1,21 @@
+---
+###############################################################################
+# Configuration of volume types for openstack.
+
+# List of volume types. Format is as required by the stackhpc.os-volumes role.
+openstack_volumes_types:
+  - "{{ openstack_volume_type_ceph_hdd }}"
+  - "{{ openstack_volume_type_ceph_ssd }}"
+
+# Volume types
+openstack_volume_type_ceph_hdd:
+  name: "ceph-hdd"
+  description: "Ceph HDD pool"
+  extra_specs:
+    volume_backend_name: "replicated-hdd"
+
+openstack_volume_type_ceph_ssd:
+  name: "ceph-ssd"
+  description: "Ceph SSD pool"
+  extra_specs:
+    volume_backend_name: "replicated-ssd"


### PR DESCRIPTION
This includes an example to configure volume types for a Ceph cluster with multiple storage classes, assuming the Cinder backends are called `replicated-hdd` and `replicated-ssd`.