### PR TITLE
bump openstack.cloud version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: openstack.cloud
-    version: 2.1.0
+    version: 2.4.1
   - name: stackhpc.openstack
     version: 0.2.4


### PR DESCRIPTION
This PR will update openstack.cloud dependency to 2.4.1.