### PR TITLE
set GRUB vars in example file

### DIFF
--- a/examples/images.yml
+++ b/examples/images.yml
@@ -20,6 +20,11 @@ openstack_images:
   - "{{ openstack_image_rocky8 }}"
   - "{{ openstack_image_ubuntu_focal }}"
 
+# Common GRUB settings for VM images
+openstack_grub_env_common:
+  DIB_GRUB_TIMEOUT: 0
+  DIB_GRUB_TIMEOUT_STYLE: hidden
+
 # CentOS Stream 8.
 openstack_image_centos_stream8:
   name: "CentOS-stream8"


### PR DESCRIPTION
Added GRUB timeout and timeout style values to images, as the ones upstream changed 5 seconds and menu respectively.
For VM images they should remain set to 0 and hidden.

Change in question:
https://review.opendev.org/c/openstack/diskimage-builder/+/937684