### PR TITLE
Update example images to new versions

### DIFF
--- a/examples/images.yml
+++ b/examples/images.yml
@@ -17,8 +17,8 @@ os_images_force_rebuild: false
 openstack_images:
   - "{{ openstack_image_centos_stream8 }}"
   - "{{ openstack_image_cirros_0_6_0 }}"
-  - "{{ openstack_image_rocky8 }}"
-  - "{{ openstack_image_ubuntu_focal }}"
+  - "{{ openstack_image_rocky9 }}"
+  - "{{ openstack_image_ubuntu_jammy }}"
 
 # Common GRUB settings for VM images
 openstack_grub_env_common:
@@ -67,9 +67,9 @@ openstack_image_cirros_0_6_0:
     os_version: "0.6.0"
     hw_rng_model: "virtio"
 
-# Rocky Linux 8.
-openstack_image_rocky8:
-  name: "Rocky8"
+# Rocky Linux 9.
+openstack_image_rocky9:
+  name: "Rocky9"
   type: raw
   elements:
     # Required for UEFI mode:
@@ -95,16 +95,16 @@ openstack_image_rocky8:
     YUM: dnf
     DIB_CONTAINERFILE_RUNTIME: docker
     DIB_CONTAINERFILE_RUNTIME_ROOT: 1
-    DIB_RELEASE: "8"
+    DIB_RELEASE: "9"
   properties:
     os_type: "linux"
     os_distro: "rocky"
-    os_version: "8"
+    os_version: "9"
     hw_rng_model: "virtio"
 
-# Ubuntu Focal 20.04.
-openstack_image_ubuntu_focal:
-  name: "Ubuntu-20.04"
+# Ubuntu Jammy 22.04.
+openstack_image_ubuntu_jammy:
+  name: "Ubuntu-22.04"
   type: raw
   is_public: true
   elements:
@@ -124,8 +124,8 @@ openstack_image_ubuntu_focal:
   properties:
     os_type: "linux"
     os_distro: "ubuntu"
-    os_version: "focal"
+    os_version: "jammy"
     hw_rng_model: "virtio"
   env:
-    DIB_RELEASE: "focal"
+    DIB_RELEASE: "jammy"
     DIB_CLOUD_INIT_DATASOURCES: "ConfigDrive"


### PR DESCRIPTION
Rocky 9 and Ubuntu Jammy are our standard versions now.