### PR TITLE
Add newer version of ansible for later python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # Use Ansible 5 for consistent Rocky 9 behaviour when available, otherwise use
 # Ansible 4
 ansible>=4,<5; python_version<"3.7"
-ansible>=5,<6; python_version>="3.7"
+ansible>=5,<6; python_version>="3.7" and python_version<"3.9"
+ansible>=8,<10; python_version>="3.9" and python_version<"3.12"
+ansible>=10,<11; python_version>="3.12"


### PR DESCRIPTION
Using too old Ansible with Python 3.12 caused ansible-galaxy to fail installing Ansible collections.
Adding later version of Ansible in ``requirements.txt`` for Python3.12