### PR TITLE
Update deprecated std_callback option

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 bin_ansible_callbacks = True
 callbacks_enabled = ansible.posix.profile_tasks
-stdout_callback = yaml
+callback_result_format = yaml


### PR DESCRIPTION
community.general.yaml has been removed from community.general 12.0.0.
The ``callback`` option was superseded by ``result_format``